### PR TITLE
Add a url to rule docs

### DIFF
--- a/lib/rules/ticket-ref.js
+++ b/lib/rules/ticket-ref.js
@@ -81,7 +81,7 @@ module.exports = {
       description: "Require a ticket reference in the TODO comment",
       category: "Fill me in",
       recommended: false,
-      url: 'https://github.com/sawyerh/eslint-plugin-todo-plz/blob/main/README.md',
+      url: "https://github.com/sawyerh/eslint-plugin-todo-plz/blob/main/docs/rules/ticket-ref.md",
     },
     fixable: null, // or "code" or "whitespace"
     messages,


### PR DESCRIPTION
When developers hover a warning/error in VSCode (and probably other code editors too) they get the description of the warning, plus the name of the rule. If docs.url is set, the Rule-Name is linked to the description page of the rule.