### PR TITLE
Correct docs in ticket-ref.md

### DIFF
--- a/docs/rules/ticket-ref.md
+++ b/docs/rules/ticket-ref.md
@@ -68,7 +68,7 @@ Examples of **correct** code for this rule when using the above options:
 
 ### `commentPattern`
 
-_Optional._ Override the overall comment pattern that matches both term and ticket. When used, `term` and `pattern` options are ignored. Expects a regex string.
+_Optional._ Override the overall comment pattern that matches both term and ticket. When used, the `pattern` option is ignored. Expects a regex string.
 
 For example, let's say you expect a different comment pattern such as `TODO: [PROJ-123]`, you would configure this rule like:
 


### PR DESCRIPTION
Changed the description of `commentPattern` so that it doesn't claim that `term` is ignored. It still needs to use the `term` to decide whether a comment is a TODO or not.

Here are the lines that use `commentPattern` alongside `term`: https://github.com/sawyerh/eslint-plugin-todo-plz/blob/4bf5a85bc26a59b29126c0c6a31c122deaf933fb/lib/rules/ticket-ref.js#L65-L70