### PR TITLE
Validate each TODO occurrence independently

### DIFF
--- a/lib/rules/ticket-ref.js
+++ b/lib/rules/ticket-ref.js
@@ -64,7 +64,7 @@ function create(context) {
 
   terms.forEach((term) => {
     termSearchPatterns[term] = new RegExp(
-      commentPattern || `${term}\\s?\\((${pattern}[,\\s]*)+\\)`,
+      `^(?:${commentPattern || `${term}\\s?\\((${pattern}[,\\s]*)+\\)`})`,
       "i",
     );
   });
@@ -75,22 +75,21 @@ function create(context) {
    */
   function validate(comment) {
     const value = comment.value;
-    const includedTerms = terms.filter((term) => value.includes(term));
-
-    if (!includedTerms.length) {
-      return;
-    }
-
-    includedTerms.forEach((term) => {
+    terms.forEach((term) => {
       const searchPattern = termSearchPatterns[term];
+      let termIndex = value.indexOf(term);
 
-      if (searchPattern.test(value)) return;
+      while (termIndex !== -1) {
+        if (!searchPattern.test(value.slice(termIndex))) {
+          context.report({
+            loc: comment.loc,
+            messageId: getMessageId({ commentPattern, description }),
+            data: { commentPattern, description, pattern, term },
+          });
+        }
 
-      context.report({
-        loc: comment.loc,
-        messageId: getMessageId({ commentPattern, description }),
-        data: { commentPattern, description, pattern, term },
-      });
+        termIndex = value.indexOf(term, termIndex + term.length);
+      }
     });
   }
 

--- a/tests/ticket-ref.js
+++ b/tests/ticket-ref.js
@@ -132,6 +132,18 @@ ruleTester.run("ticket-ref", rule, {
       options: [options.jira],
     },
     {
+      code: `/**
+              * TODO: Connect to the API
+              * TODO (PROJ-123): Document the API
+              */`,
+      errors: [
+        {
+          message: messages.missingTodoTicket,
+        },
+      ],
+      options: [options.jira],
+    },
+    {
       code: "// FIXME: Connect to the API",
       errors: [{ message: messages.missingFixmeTicket }],
       options: [{ pattern, terms: ["FIXME"] }],


### PR DESCRIPTION
## Summary
- validate every configured term occurrence instead of accepting one match per comment
- anchor ticket validation at the occurrence being checked
- add regression coverage for mixed valid and invalid TODOs in one block comment

## Verification
- npm test (24 passing)