### PR TITLE
Escape configured TODO terms

### DIFF
--- a/lib/rules/ticket-ref.js
+++ b/lib/rules/ticket-ref.js
@@ -25,6 +25,10 @@ function getMessageId({ commentPattern, description }) {
   return "missingTicket";
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 const schema = [
   {
     type: "object",
@@ -63,8 +67,9 @@ function create(context) {
   const termSearchPatterns = {};
 
   terms.forEach((term) => {
+    const escapedTerm = escapeRegExp(term);
     termSearchPatterns[term] = new RegExp(
-      commentPattern || `${term}\\s?\\((${pattern}[,\\s]*)+\\)`,
+      commentPattern || `${escapedTerm}\\s?\\((${pattern}[,\\s]*)+\\)`,
       "i",
     );
   });

--- a/tests/ticket-ref.js
+++ b/tests/ticket-ref.js
@@ -74,6 +74,10 @@ ruleTester.run("ticket-ref", rule, {
       options: [{ pattern, terms: ["FIXME"] }],
     },
     {
+      code: "// C++ (PROJ-2): Upgrade the toolchain",
+      options: [{ pattern, terms: ["C++"] }],
+    },
+    {
       code: "// TODO: [PROJ-2] Connect to the API",
       options: [{ commentPattern }],
     },
@@ -135,6 +139,15 @@ ruleTester.run("ticket-ref", rule, {
       code: "// FIXME: Connect to the API",
       errors: [{ message: messages.missingFixmeTicket }],
       options: [{ pattern, terms: ["FIXME"] }],
+    },
+    {
+      code: "// C++: Upgrade the toolchain",
+      errors: [
+        {
+          message: `C++ comment doesn't reference a ticket number. Ticket pattern: ${pattern}`,
+        },
+      ],
+      options: [{ pattern, terms: ["C++"] }],
     },
     {
       code: "// TODO (PROJ-123) Connect to the API",


### PR DESCRIPTION
## Summary
- treat configured terms as literal text when building validation regexes
- prevent regex syntax errors and unintended metacharacter behavior
- add valid and invalid coverage for a `C++` term

## Verification
- npm test (25 passing)