### PR TITLE
Enforce the ticket-ref option contract

### DIFF
--- a/lib/rules/ticket-ref.js
+++ b/lib/rules/ticket-ref.js
@@ -28,6 +28,8 @@ function getMessageId({ commentPattern, description }) {
 const schema = [
   {
     type: "object",
+    additionalProperties: false,
+    anyOf: [{ required: ["pattern"] }, { required: ["commentPattern"] }],
     properties: {
       commentPattern: {
         type: "string",
@@ -40,6 +42,8 @@ const schema = [
       },
       terms: {
         type: "array",
+        minItems: 1,
+        uniqueItems: true,
         items: {
           type: "string",
         },

--- a/tests/ticket-ref.js
+++ b/tests/ticket-ref.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const Linter = require("eslint").Linter;
 const RuleTester = require("eslint").RuleTester;
 const rule = require("../lib/rules/ticket-ref");
 const ruleTester = new RuleTester();
@@ -142,9 +143,9 @@ ruleTester.run("ticket-ref", rule, {
       options: [{ commentPattern }],
     },
     {
-      code: "// TODO (PROJ-123) Connect to the API",
+      code: "// TODO (TASK-123) Connect to the API",
       errors: [{ message: messages.missingTicketWithDescription }],
-      options: [{ description }],
+      options: [{ pattern, description }],
     },
   ],
 });
@@ -184,5 +185,46 @@ describe("ticket-ref source code compatibility", () => {
         })
       );
     });
+  });
+});
+
+describe("ticket-ref option schema", () => {
+  function verifyWithOptions(ruleOptions) {
+    const linter = new Linter();
+
+    return linter.verify("// TODO: Connect to the API", [
+      {
+        plugins: {
+          "todo-plz": {
+            rules: { "ticket-ref": rule },
+          },
+        },
+        rules: {
+          "todo-plz/ticket-ref": ["error", ruleOptions],
+        },
+      },
+    ]);
+  }
+
+  it("requires a ticket pattern or an overall comment pattern", () => {
+    assert.throws(() => verifyWithOptions({}), /should have required property/);
+  });
+
+  it("rejects empty and duplicate term lists", () => {
+    assert.throws(
+      () => verifyWithOptions({ pattern, terms: [] }),
+      /should NOT have fewer than 1 items/,
+    );
+    assert.throws(
+      () => verifyWithOptions({ pattern, terms: ["TODO", "TODO"] }),
+      /should NOT have duplicate items/,
+    );
+  });
+
+  it("rejects unknown options", () => {
+    assert.throws(
+      () => verifyWithOptions({ pattern, typo: true }),
+      /should NOT have additional properties/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- require either `pattern` or `commentPattern`
- reject empty or duplicate term lists and unknown properties
- test invalid options through ESLint configuration validation
- correct the description test to include its documented ticket pattern

## Verification
- npm test (26 passing)