### PR TITLE
Assert ESLint integration results

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lib"
   ],
   "scripts": {
-    "lint": "cd tests/integration && eslint .",
+    "lint": "eslint --no-config-lookup lib tests/ticket-ref.js tests/integration-test.js",
     "test": "mocha tests"
   },
   "devDependencies": {

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const assert = require("assert");
+const path = require("path");
+const ESLint = require("eslint").ESLint;
+
+describe("flat config integration", () => {
+  it("loads the plugin and reports the expected invalid comments", async () => {
+    const integrationDirectory = path.join(__dirname, "integration");
+    const eslint = new ESLint({
+      cwd: integrationDirectory,
+      overrideConfigFile: path.join(integrationDirectory, "eslint.config.js"),
+    });
+    const results = await eslint.lintFiles(["index.js", "commentPattern.js"]);
+    const errors = results.flatMap((result) =>
+      result.messages.map((message) => ({
+        file: path.basename(result.filePath),
+        line: message.line,
+        messageId: message.messageId,
+        ruleId: message.ruleId,
+      })),
+    );
+
+    assert.deepStrictEqual(errors, [
+      {
+        file: "index.js",
+        line: 4,
+        messageId: "missingTicket",
+        ruleId: "todo-plz/ticket-ref",
+      },
+      {
+        file: "commentPattern.js",
+        line: 4,
+        messageId: "missingTicketWithCommentPattern",
+        ruleId: "todo-plz/ticket-ref",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- run the flat-config fixtures through ESLint from the unit test suite
- assert exact files, lines, rule IDs, and message IDs
- make `npm run lint` a successful source check instead of an expected failure

## Verification
- npm test (24 passing)
- npm run lint