### PR TITLE
Detect configured terms case-insensitively

### DIFF
--- a/docs/rules/ticket-ref.md
+++ b/docs/rules/ticket-ref.md
@@ -34,7 +34,8 @@ Examples of **correct** code for this rule when using the above options:
 
 ### `terms`
 
-_Optional._ Change what terms to require the ticket reference on. Defaults to: `["TODO"]`
+_Optional._ Change what terms to require the ticket reference on. Matching is
+case-insensitive. Defaults to: `["TODO"]`
 
 ```json
 {

--- a/lib/rules/ticket-ref.js
+++ b/lib/rules/ticket-ref.js
@@ -75,7 +75,10 @@ function create(context) {
    */
   function validate(comment) {
     const value = comment.value;
-    const includedTerms = terms.filter((term) => value.includes(term));
+    const normalizedValue = value.toLowerCase();
+    const includedTerms = terms.filter((term) =>
+      normalizedValue.includes(term.toLowerCase()),
+    );
 
     if (!includedTerms.length) {
       return;

--- a/tests/ticket-ref.js
+++ b/tests/ticket-ref.js
@@ -119,6 +119,15 @@ ruleTester.run("ticket-ref", rule, {
       options: [options.jira],
     },
     {
+      code: "// todo: Connect to the API",
+      errors: [
+        {
+          message: messages.missingTodoTicket,
+        },
+      ],
+      options: [options.jira],
+    },
+    {
       code: `/**
               * Description
               * TODO: Connect to the API


### PR DESCRIPTION
## Summary
- align term detection with the existing case-insensitive validation regex
- report lowercase TODOs that omit ticket references
- document case-insensitive term matching

## Verification
- npm test (24 passing)