### PR TITLE
Match only standalone TODO terms

### DIFF
--- a/lib/rules/ticket-ref.js
+++ b/lib/rules/ticket-ref.js
@@ -25,6 +25,29 @@ function getMessageId({ commentPattern, description }) {
   return "missingTicket";
 }
 
+function includesStandaloneTerm(value, term) {
+  if (!term) {
+    return false;
+  }
+
+  let termIndex = value.indexOf(term);
+
+  while (termIndex !== -1) {
+    const precedingCharacter = value[termIndex - 1];
+    const followingCharacter = value[termIndex + term.length];
+    const hasWordCharacterBefore = /[A-Za-z0-9_]/.test(precedingCharacter || "");
+    const hasWordCharacterAfter = /[A-Za-z0-9_]/.test(followingCharacter || "");
+
+    if (!hasWordCharacterBefore && !hasWordCharacterAfter) {
+      return true;
+    }
+
+    termIndex = value.indexOf(term, termIndex + term.length);
+  }
+
+  return false;
+}
+
 const schema = [
   {
     type: "object",
@@ -75,7 +98,9 @@ function create(context) {
    */
   function validate(comment) {
     const value = comment.value;
-    const includedTerms = terms.filter((term) => value.includes(term));
+    const includedTerms = terms.filter((term) =>
+      includesStandaloneTerm(value, term),
+    );
 
     if (!includedTerms.length) {
       return;

--- a/tests/ticket-ref.js
+++ b/tests/ticket-ref.js
@@ -51,6 +51,14 @@ ruleTester.run("ticket-ref", rule, {
       options: [options.jira],
     },
     {
+      code: "// NOTTODO is a documentation label",
+      options: [options.jira],
+    },
+    {
+      code: "// TODO_LIST stores documentation tasks",
+      options: [options.jira],
+    },
+    {
       code: `/**
               * Description
               * TODO (PROJ-123): Connect to the API


### PR DESCRIPTION
## Summary
- recognize configured terms only when they are not embedded in larger word-like tokens
- avoid false positives for names such as `NOTTODO` and `TODO_LIST`
- safely ignore an empty configured term on this independent branch

## Verification
- npm test (25 passing)