### PR TITLE
Clean up ticket-ref rule metadata

### DIFF
--- a/lib/rules/ticket-ref.js
+++ b/lib/rules/ticket-ref.js
@@ -103,11 +103,9 @@ module.exports = {
   meta: {
     docs: {
       description: "Require a ticket reference in the TODO comment",
-      category: "Fill me in",
       recommended: false,
       url: "https://github.com/sawyerh/eslint-plugin-todo-plz/blob/main/docs/rules/ticket-ref.md",
     },
-    fixable: null, // or "code" or "whitespace"
     messages,
     schema,
     type: "suggestion",

--- a/tests/ticket-ref.js
+++ b/tests/ticket-ref.js
@@ -186,3 +186,10 @@ describe("ticket-ref source code compatibility", () => {
     });
   });
 });
+
+describe("ticket-ref metadata", () => {
+  it("does not advertise unsupported or placeholder capabilities", () => {
+    assert.strictEqual(Object.hasOwn(rule.meta.docs, "category"), false);
+    assert.strictEqual(Object.hasOwn(rule.meta, "fixable"), false);
+  });
+});


### PR DESCRIPTION
## Summary
- remove the placeholder docs category
- omit the unsupported `fixable` field
- add a metadata contract test

## Verification
- npm test (24 passing)